### PR TITLE
used toString Method

### DIFF
--- a/Java/Exception Handling/Java Exception Handling (Try-catch)/Solution.java
+++ b/Java/Exception Handling/Java Exception Handling (Try-catch)/Solution.java
@@ -13,7 +13,8 @@ public class Solution {
         } catch (InputMismatchException e) {
             System.out.println(e.getClass().getName());
         } catch (ArithmeticException e) {
-            System.out.println(e.getClass().getName() + ": / by zero");
+//             System.out.println(e.getClass().getName() + ": / by zero");
+            System.out.println(e.toString());
         }
     }
 }


### PR DESCRIPTION
Updated Solution.java
We can use toString Method instead of our string  
Just observe the print statements of catch...

```java
try{
            int x = input.nextInt();
            int y = input.nextInt();
            System.out.println(x/y);
        }
        catch(InputMismatchException e){
            // System.out.println("java.util.InputMismatchException");
            System.out.println(e.getClass().getName());
        }
        catch(ArithmeticException e){
            // System.out.println("java.lang.ArithmeticException: / by zero");
            System.out.println(e.toString());
        }
``` 